### PR TITLE
lint to ensure that all types end in Type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,10 @@
     "spy": false
   },
   "rules": {
+    "flowtype/type-id-match": [
+      2,
+      "^([A-Z][a-z0-9]*)+Type$"
+    ],
     "flowtype/require-valid-file-annotation": [
       2,
       "always", {

--- a/src/user-names/index.js
+++ b/src/user-names/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-type User =
+type UserType =
   | {
       firstName?: string,
       lastName?: string,
@@ -16,10 +16,15 @@ type User =
 
 const getInitial = (str: string) => str.charAt(0).toUpperCase();
 
-export const getInitials = ({ firstName = '', lastName = '' }: User): string =>
-  `${getInitial(firstName)}${getInitial(lastName)}`;
+export const getInitials = ({
+  firstName = '',
+  lastName = '',
+}: UserType): string => `${getInitial(firstName)}${getInitial(lastName)}`;
 
-export const getFullName = ({ firstName = '', lastName = '' }: User): string =>
+export const getFullName = ({
+  firstName = '',
+  lastName = '',
+}: UserType): string =>
   firstName && lastName ? `${firstName} ${lastName}` : `${firstName}`;
 
 export const makePossessive = (name: string): string =>


### PR DESCRIPTION
### Status
**READY**

### Description
Just a quick linter rule to enforce that all our defined types end in `Type`