### PR TITLE
Support Webpack by using default import of big.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.8.1 -2018-08-01
+- currency utils use default import of big.js
+
 ## 0.8.0 - 2018-08-01
 ### Added
 - localStorage util

--- a/src/currency/index.js
+++ b/src/currency/index.js
@@ -1,4 +1,5 @@
 // @flow
+//now use default import here (no brances) to support webpack 
 import Big from 'big.js';
 
 const numberWithCommas = (number: number): string =>

--- a/src/currency/index.js
+++ b/src/currency/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { Big } from 'big.js';
+import Big from 'big.js';
 
 const numberWithCommas = (number: number): string =>
   new Big(number).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/src/currency/index.js
+++ b/src/currency/index.js
@@ -1,5 +1,4 @@
 // @flow
-//now use default import here (no brances) to support webpack 
 import Big from 'big.js';
 
 const numberWithCommas = (number: number): string =>


### PR DESCRIPTION
### Status
**READY/IN-PROGRESS/HOLD**
Ready

### Description
**FEATURE/BUG FIX/REFACTOR**

In order to import the currency module through webpack, the default export from big.js must be used, else a _big.Big will not be a constructor.

### Related PRs

N/A


### Note to Reviewers
Please ensure that my documentation is in the correct style!

### Quality Checklist:
These are mandatory and must be completed before merging the PR

- [ ] New, changed or refactored functionality has tests.
^ I was unsure how to test module loading as it is somewhat outside the scope of this repo
- [x] New, changed or refactored functionality has documentation.
- [x] New, changed or refactored functionality has been QA'd.
- [x] New, changed or refactored functionality has been added to the CHANGELOG.
