### PR TITLE
rounding functions

### DIFF
--- a/src/currency/index.js
+++ b/src/currency/index.js
@@ -1,14 +1,15 @@
 // @flow
 import Big from 'big.js';
+import { roundToTwoDecimalPlaces, roundToZeroDecimalPlaces } from '../round';
 
 const numberWithCommas = (number: number): string =>
   new Big(number).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
 export const centsToDollars = (cents: number): number =>
-  Number(new Big(cents / 100).toFixed(2));
+  roundToTwoDecimalPlaces(new Big(cents / 100));
 
 export const dollarsToCents = (dollars: number): number =>
-  Number(new Big(dollars * 100).toFixed(0));
+  roundToZeroDecimalPlaces(new Big(dollars * 100));
 
 export const formatCentsToDollars = (cents: number): string =>
   `$${numberWithCommas(centsToDollars(cents))}`;

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,20 @@ export {
 export { pluralize, pluralizeWithCount } from './pluralize';
 
 export {
+  roundToXDecimalPlaces,
+  roundToZeroDecimalPlaces,
+  roundToTwoDecimalPlaces,
+} from './round';
+
+export {
   formatTime,
   formatHours,
   formatTimeWithPeriod,
   combinedDateAndTime,
+  minutesToHours,
+  hoursToMinutes,
+  formatMinutesToHours,
+  formatHoursToMinutes,
 } from './time';
 
 export { calculateUserAge } from './users/age';

--- a/src/round/index.js
+++ b/src/round/index.js
@@ -1,0 +1,12 @@
+// @flow
+
+export const roundToXDecimalPlaces = (
+  numberOfPlaces: number,
+  n: number,
+): number => Number(n.toFixed(numberOfPlaces));
+
+export const roundToZeroDecimalPlaces = (n: number) =>
+  roundToXDecimalPlaces(0, n);
+
+export const roundToTwoDecimalPlaces = (n: number) =>
+  roundToXDecimalPlaces(2, n);

--- a/src/round/index.test.js
+++ b/src/round/index.test.js
@@ -1,0 +1,189 @@
+// @flow
+
+import {
+  roundToXDecimalPlaces,
+  roundToZeroDecimalPlaces,
+  roundToTwoDecimalPlaces,
+} from './index';
+
+const roundToXTestValues = [
+  {
+    number: 123456789.123456789,
+    places: 0,
+    output: 123456789,
+  },
+  {
+    number: 123456789.123456789,
+    places: 2,
+    output: 123456789.12,
+  },
+  {
+    number: 123456789.123456789,
+    places: 3,
+    output: 123456789.123,
+  },
+  {
+    number: 123456789.123456789,
+    places: 4,
+    output: 123456789.1235,
+  },
+  {
+    number: 123456789.123456789,
+    places: 5,
+    output: 123456789.12346,
+  },
+  {
+    number: 123456789.123456789,
+    places: 6,
+    output: 123456789.123457,
+  },
+  {
+    number: 123456789.123456789,
+    places: 7,
+    output: 123456789.1234568,
+  },
+  {
+    number: 123456789.123456789,
+    places: 8,
+    output: 123456789.12345679,
+  },
+  {
+    number: 123456789.123456789,
+    places: 9,
+    output: 123456789.123456789,
+  },
+];
+
+describe('roundToZeroDecimalPlaces', () => {
+  it('returns the expected result', () => {
+    roundToXTestValues.forEach(({ number, places, output }) =>
+      expect(roundToXDecimalPlaces(places, number)).toEqual(output),
+    );
+  });
+});
+
+const roundToZeroTestValues = [
+  {
+    input: 120,
+    output: 120,
+  },
+  {
+    input: 12345,
+    output: 12345,
+  },
+  {
+    input: 0,
+    output: 0,
+  },
+  {
+    input: 1,
+    output: 1,
+  },
+  {
+    input: -1,
+    output: -1,
+  },
+  {
+    input: 12,
+    output: 12,
+  },
+  {
+    input: 12.12,
+    output: 12,
+  },
+  {
+    input: 12.823,
+    output: 13,
+  },
+  {
+    input: -12.123,
+    output: -12,
+  },
+  {
+    input: 12.925,
+    output: 13,
+  },
+  {
+    input: -12.925,
+    output: -13,
+  },
+  {
+    input: 12.123242142141241231321321241412341231231231232,
+    output: 12,
+  },
+  {
+    input: -12.823242142141241231321321241412341231231231232,
+    output: -13,
+  },
+];
+
+describe('roundToZeroDecimalPlaces', () => {
+  it('returns the expected result', () => {
+    roundToZeroTestValues.forEach(({ input, output }) =>
+      expect(roundToZeroDecimalPlaces(input)).toEqual(output),
+    );
+  });
+});
+
+const roundToTwoTestValues = [
+  {
+    input: 120,
+    output: 120,
+  },
+  {
+    input: 12345,
+    output: 12345,
+  },
+  {
+    input: 0,
+    output: 0,
+  },
+  {
+    input: 1,
+    output: 1,
+  },
+  {
+    input: -1,
+    output: -1,
+  },
+  {
+    input: 12,
+    output: 12,
+  },
+  {
+    input: 12.12,
+    output: 12.12,
+  },
+  {
+    input: 12.123,
+    output: 12.12,
+  },
+  {
+    input: -12.123,
+    output: -12.12,
+  },
+  {
+    input: 12.125,
+    output: 12.13,
+  },
+  {
+    input: -12.125,
+    output: -12.13,
+  },
+  {
+    input: 12.123242142141241231321321241412341231231231232,
+    output: 12.12,
+  },
+  {
+    input: -12.123242142141241231321321241412341231231231232,
+    output: -12.12,
+  },
+];
+
+describe('roundToTwoDecimalPlaces', () => {
+  it('returns the expected result', () => {
+    roundToTwoTestValues.forEach(({ input, output }) =>
+      expect(roundToTwoDecimalPlaces(input)).toEqual(output),
+    );
+  });
+});

--- a/src/time/index.js
+++ b/src/time/index.js
@@ -1,6 +1,7 @@
 // @flow
 import moment from 'moment';
 import { pluralizeWithCount } from '../pluralize';
+import { roundToZeroDecimalPlaces, roundToTwoDecimalPlaces } from '../round';
 
 export const formatHours = (hours: number): string =>
   pluralizeWithCount(hours, 'hour');
@@ -34,3 +35,15 @@ export const combinedDateAndTime = (date: moment, time: moment) =>
     .hour(time.get('hour'))
     .minute(time.get('minute'))
     .format();
+
+export const minutesToHours = (durationInMinutes: number) =>
+  roundToZeroDecimalPlaces(durationInMinutes / 60);
+
+export const hoursToMinutes = (durationInHours: number) =>
+  roundToTwoDecimalPlaces(durationInHours * 60);
+
+export const formatMinutesToHours = (durationInMinutes: number) =>
+  formatHours(minutesToHours(durationInMinutes));
+
+export const formatHoursToMinutes = (durationInHours: number) =>
+  formatMinutes(hoursToMinutes(durationInHours));


### PR DESCRIPTION
### Status
**READY**

### Description
**FEATURE**

We've implemented rounding a few different ways in various places

elsewhere I've found:

```
Math.round(x * 1e2) / 1e2
```

After running some tests it turns out that this implementation is slightly more accurate and it seems worthwhile to standardize and extract this stuff so that we can easily find everywhere we're doing rounding on the frontend.

I wrote named functions for `roundToZeroDecimalPlaces` and `roundToTwoDecimalPlaces` because these two are the most commonly used + it makes them a bit more readable when you're skimming code.